### PR TITLE
MicroPython: Obtain i2c bus object from constructor

### DIFF
--- a/micropython/DFRobot_MAX17043.py
+++ b/micropython/DFRobot_MAX17043.py
@@ -1,10 +1,5 @@
 import time
 
-from machine import I2C, Pin
-
-# Get I2C bus
-i2c = I2C(scl = Pin(22), sda = Pin(21), freq=400000)
-
 MAX17043_ADDR = 0x36
 MAX17043_VCELL = 0x02
 MAX17043_SOC = 0x04
@@ -14,10 +9,10 @@ MAX17043_CONFIG = 0x0c
 MAX17043_COMMAND = 0xfe
 
 class DFRobot_MAX17043():
-  
-  def __init__(self):
-    pass
-  
+
+  def __init__(self, i2c):
+    self.i2c = i2c
+
   def begin(self):
     self.write16(MAX17043_COMMAND, 0x5400)
     time.sleep(0.01)
@@ -28,10 +23,10 @@ class DFRobot_MAX17043():
       return 0
     else:
       return -1
-      
+
   def readVoltage(self):
     return (1.25 * (self.read16(MAX17043_VCELL) >> 4))
-  
+
   def readPercentage(self):
     tmp = self.read16(MAX17043_SOC)
     return ((tmp >> 8) + 0.003906 * (tmp & 0x00ff))
@@ -46,23 +41,23 @@ class DFRobot_MAX17043():
 
   def clearInterrupt(self):
     self.writeRegBits(MAX17043_CONFIG, 0, 0x01, 5)
-    
+
   def setSleep(self):
     self.writeRegBits(MAX17043_CONFIG, 1, 0x01, 7)
-    
+
   def setWakeUp(self):
     self.writeRegBits(MAX17043_CONFIG, 0, 0x01, 7)
-  
+
   def write16(self, reg, dat):
     buf = bytearray(2)
     buf[0] = dat >> 8
     buf[1] = dat & 0x00ff
-    i2c.writeto_mem(MAX17043_ADDR, reg, buf)
-    
+    self.i2c.writeto_mem(MAX17043_ADDR, reg, buf)
+
   def read16(self, reg):
-    buf = i2c.readfrom_mem(MAX17043_ADDR, reg, 2)
+    buf = self.i2c.readfrom_mem(MAX17043_ADDR, reg, 2)
     return ((buf[0] << 8) | buf[1])
-  
+
   def writeRegBits(self, reg, dat, bits, offset):
     tmp = self.read16(reg)
     tmp = (tmp & (~(bits << offset))) | (dat << offset)

--- a/micropython/DFRobot_MAX17043_demo.py
+++ b/micropython/DFRobot_MAX17043_demo.py
@@ -1,8 +1,11 @@
 import time
-from machine import Pin
+from machine import I2C, Pin
 from DFRobot_MAX17043 import DFRobot_MAX17043
 
-gauge = DFRobot_MAX17043()
+# Get I2C bus
+i2c = I2C(scl = Pin(22), sda = Pin(21), freq=400000)
+
+gauge = DFRobot_MAX17043(i2c)
 
 def interruptCallBack(channel):
   gauge.clearInterrupt()

--- a/micropython/readme.md
+++ b/micropython/readme.md
@@ -39,7 +39,7 @@ To use this library download the zip file, uncomperss it to a folder named DFRob
  #
  # @return MAX17043 object
 #
-DFRobot_MAX17043();
+DFRobot_MAX17043(i2c);
 
 #
  # @brief MAX17043 begin and test moudle


### PR DESCRIPTION
Hi there,

this makes the `DFRobot_MAX17043` instance obtain the I2C bus object from its constructor, making its usage more flexible as the I2C bus object will not be instantiated on the module level already.

See also https://community.hiveeyes.org/t/add-support-for-the-max17043-within-terkin/2734.

Cheers,
Andreas.